### PR TITLE
Document 406 Not Acceptable

### DIFF
--- a/draft-wood-ohai-unreliable-ohttp.md
+++ b/draft-wood-ohai-unreliable-ohttp.md
@@ -191,8 +191,8 @@ unreliable delivery up to the Relay and Gateway Resources.
 
 Upon receipt of an unreliable OHTTP request from the Client, the Oblivious
 Relay Resource MUST reply with a `202 Accepted` response with the "message/ohttp-ack"
-content type to the Client. It SHOULD buffer the request to be sent to the Oblivious
-Gateway Resource at some point in the future, but MAY chose to forward it immediately.
+content type to the Client. It can buffer the request to be sent to the Oblivious
+Gateway Resource at some point in the future, or choose to forward it immediately.
 Similarly, upon receipt of an
 unreliable OHTTP request from the Oblivious Relay Resource, the Oblivious Gateway
 Resource MUST reply with a `202 Accepted` response and the "message/ohttp-ack"

--- a/draft-wood-ohai-unreliable-ohttp.md
+++ b/draft-wood-ohai-unreliable-ohttp.md
@@ -230,7 +230,7 @@ request became too old.
 
 A Relay which supports unreliable OHTTP may be configured to enforce
 unreliable delivery. In such cases, if the Relay receives a normal
-OHTTP request, i.e. without an Accept header matching "message/ohttp-ack",
+OHTTP request, i.e., without an Accept header matching "message/ohttp-ack",
 it SHOULD respond with `406 Not Acceptable` to signal this requirement
 to the client. If a Relay has forwarded an Encapsulated Request and
 receives a `406 Not Acceptable` response, it MUST return the same status

--- a/draft-wood-ohai-unreliable-ohttp.md
+++ b/draft-wood-ohai-unreliable-ohttp.md
@@ -64,11 +64,11 @@ In a typical OHTTP transaction, Clients receive an Encapsulated Response
 from the Oblivious Gateway Resource containing the response from the Target
 Resource. This is useful for applications that require a response from the
 Target Resource. However, there are many settings in which Clients do not require
-a response from the Target Resource, including, but not limited to: privacy-preserving data
+a response from the Target Resource, including privacy-preserving data
 collection {{?STAR=I-D.dss-star}}, publish-subscribe applications, and more generally
-applications which unreliably "fire and forget" data to targets. Beyond these application
-use cases, unreliable requests also enable the relay to play a more active role towards
-improving client privacy, e.g., by batching, buffering, and shuffling requests to
+applications which submit data under a "best effort" policy. Beyond these application
+use cases, unreliable requests also allow the relay to play a more active role towards
+improving client privacy, e.g. by batching, buffering, and shuffling requests to
 mitigate traffic analysis by network eavesdroppers or amplify local differential privacy
 protections used by clients {{?LOCALDP=DOI.10.48550/arXiv.1811.12469}}.
 

--- a/draft-wood-ohai-unreliable-ohttp.md
+++ b/draft-wood-ohai-unreliable-ohttp.md
@@ -252,13 +252,6 @@ Encapsulated Response. The Relay Resource will forward this to the
 Client, and the Client can then fail or retry with unreliable delivery according to
 its own requirements.
 
-Note that while it's possible for the Gateway to decide whether to
-require an unreliable OHTTP request based on information in the
-Encapsulated Request, doing so leaks information about the contents
-to the Relay. Implementations must take this into account in
-deployment so they do not violate the privacy properties of the
-OHTTP channel.
-
 
 # Security Considerations {#security}
 

--- a/draft-wood-ohai-unreliable-ohttp.md
+++ b/draft-wood-ohai-unreliable-ohttp.md
@@ -187,9 +187,7 @@ in the Accept header (see {{iana-ack}}). The Client receives a `202 Accepted`
 response with content type "message/ohttp-ack" and an empty body upon successful
 transmission of the request. If the Accept header also allows the normal
 "message/bhttp" content type, the client has left the choice of reliable or
-unreliable delivery up to the Relay and Gateway Resources, which may
-return "200 OK" along with an Encapsulated Body instead.
-Any other response is considered invalid.
+unreliable delivery up to the Relay and Gateway Resources.
 
 Upon receipt of an unreliable OHTTP request from the Client, the Oblivious
 Relay Resource MUST reply with a `202 Accepted` response with the "message/ohttp-ack"

--- a/draft-wood-ohai-unreliable-ohttp.md
+++ b/draft-wood-ohai-unreliable-ohttp.md
@@ -247,7 +247,7 @@ is dropped or discarded due to it being stale.
 
 If an Oblivious Gateway Resource requires unreliable delivery for a
 request, by implementation constraint or policy, it SHOULD respond
-with `406 Not Acceptable` to any requests which require return of an
+with `406 Not Acceptable` to any requests which require reliable return of an
 Encapsulated Response. The Relay Resource will forward this to the
 Client, which can fail or retry with unreliable delivery according to
 its own requirements.

--- a/draft-wood-ohai-unreliable-ohttp.md
+++ b/draft-wood-ohai-unreliable-ohttp.md
@@ -249,7 +249,7 @@ If an Oblivious Gateway Resource requires unreliable delivery for a
 request, by implementation constraint or policy, it SHOULD respond
 with `406 Not Acceptable` to any requests which require reliable return of an
 Encapsulated Response. The Relay Resource will forward this to the
-Client, which can fail or retry with unreliable delivery according to
+Client, and the Client can then fail or retry with unreliable delivery according to
 its own requirements.
 
 Note that while it's possible for the Gateway to decide whether to


### PR DESCRIPTION
Recommend Relay and Gateway use the `406 Not Acceptable` status code to signal unreliable OHTTP as a requirement to the Client.

Also some more editoral.